### PR TITLE
WEB-12: Add CI pipeline

### DIFF
--- a/.github/workflows/jestci.yml
+++ b/.github/workflows/jestci.yml
@@ -1,0 +1,30 @@
+name: Jest CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          cache-dependency-path: ./yarn.lock
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run Jest tests
+        run: yarn test


### PR DESCRIPTION
## Overview

Create a CI pipeline that runs the Jest testing suite.

## Changes Made

- Create a `jestci.yml` file that triggers a GitHub Actions workflow on push and PRs to `main`.

## Test Coverage

- Create a PR to merge onto `main` and the GitHub actions should trigger.
- Or you can see that this PR triggers the actions as well.

## Screenshots

<img width="1440" alt="Screenshot 2024-08-18 at 10 00 28 PM" src="https://github.com/user-attachments/assets/a09b6a0c-40b3-4591-a550-5163bb917392">
